### PR TITLE
fix broken link in readme to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Docusaurus is an open-source library, built with React, to create and maintain d
 
 ## Contributing
 
-See [Contributing](Contributing.md)
+See [Contributing](CONTRIBUTING.md)


### PR DESCRIPTION
I noticed that the current link didn't connect correctly, updating the capitalization should fix it.