### PR TITLE
tensorflow r1.0.0 needs numpy 1.11.0

### DIFF
--- a/docs/training-setup.md
+++ b/docs/training-setup.md
@@ -74,7 +74,7 @@ You should see (ml5) prepended before your terminal prompt
 Create a file called `requirements.txt` and paste the following into it.
 
 ```
-numpy==1.10.4
+numpy==1.11.0
 scipy==0.17.0
 tensorflow==1.0.0
 ```


### PR DESCRIPTION
Hi! I found that tensorflow r1.0.0 needs numpy 1.11.0 as a requirement when setting up a fresh install.
<img width="647" alt="screen shot 2018-11-13 at 1 22 24 pm" src="https://user-images.githubusercontent.com/8598597/48445758-3525ca80-e74c-11e8-9fd8-ca04d591045f.png">
