### PR TITLE
Fix link for Firefox

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -179,9 +179,11 @@ class Examples extends React.Component {
   render() {
     return (
       <div className="ExamplesLinkBlock ">
-        <button className="btn-blue mt40 ex">
-          <a href="/docs/quick-start"> 🌟 See Examples 🌟 </a> 
-        </button>
+        <a href="/docs/quick-start">
+          <button className="btn-blue mt40 ex">
+            🌟 See Examples 🌟
+          </button>
+        </a>
       </div>
     );
   }


### PR DESCRIPTION
There is a small problem with the link "See Examples", the markup is not valid on Firefox and is impossible to click the link as mentioned on this issue https://stackoverflow.com/questions/17253410/link-inside-a-button-not-working-in-firefox. 

I just wrapped the button on the link to make it work.