### PR TITLE
change broken references to LSTMGenerator() to charRNN()

### DIFF
--- a/docs/training-LSTM.md
+++ b/docs/training-LSTM.md
@@ -3,7 +3,7 @@ id: training-lstm
 title: Training a LSTM 
 ---
 
-This short tutorial will go over how to train a custom LSTM on your own dataset and then use the results in ml5.js [LSTMGenerator()](/docs/LSTMGenerator) method. For this, you will need a dataset of text you would like to use. Take a look at some of the ones we are using [here](https://github.com/ml5js/ml5-data-and-models/tree/master/datasets/text).
+This short tutorial will go over how to train a custom LSTM on your own dataset and then use the results in ml5.js [charRNN()](/docs/CharRNN) method. For this, you will need a dataset of text you would like to use. Take a look at some of the ones we are using [here](https://github.com/ml5js/ml5-data-and-models/tree/master/datasets/text).
 
 The code for this tutorial is based on [Sherjil Ozair](https://github.com/sherjilozair/char-rnn-tensorflow) version of [Andrej Karpathy's](https://karpathy.github.io/) [char-rnn code](https://github.com/karpathy/char-rnn).
 
@@ -77,7 +77,7 @@ python train.py --data_dir=./bronte \
 Once the model is ready, you'll just need to point to it in your ml5 sketch:
 
 ```javascript
-const lstm = new ml5.LSTMGenerator('./models/your_new_model');
+const rnn = new ml5.charRNN('./models/your_new_model');
 ```
 
 That's it!


### PR DESCRIPTION
was working on CharRnn and noticed that the documentation links are broken/the code sample uses an outdated function name (LSTMGenerator() instead of charRNN()).

Might be worth considering just changing all the references to LSTM to charRNN to avoid confusion?